### PR TITLE
feat(*): run benchmarks in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1.4
+
+FROM nvidia/cuda:12.6.3-runtime-ubuntu22.04
+
+# Avoid prompts
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=America/New_York
+
+WORKDIR /src
+
+COPY requirements/requirements.txt /src/requirements/requirements.txt
+
+# Install system dependencies and Python packages
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/var/cache/apt \
+    apt-get update || true && \
+    apt-get install -y --no-install-recommends curl ffmpeg git nano software-properties-common tree wget && \
+    add-apt-repository ppa:deadsnakes/ppa || true && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    apt-get update || true && \
+    apt-get install -y --no-install-recommends cuda-minimal-build-12-6 && \
+    apt-get install -y --no-install-recommends python3.10 python3-dev && \
+    ln -s `which python3.10` /usr/bin/python && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python && \
+    pip install --timeout 300 --root-user-action=ignore -r requirements/requirements.txt && \
+    # Clean up:
+    python -m pip cache purge && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    find / -type f -name "*.pyc" -delete && \
+    find / -type d -name "__pycache__" -exec rm -rf {} + && \
+    rm -rf /usr/share/doc/* && \
+    rm -rf /usr/share/man/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/* && \
+    rm -rf /var/cache/apt/* && \
+    find / -type d -name ".git" -exec rm -rf {} + && \
+    find / -name "*.a" -or -name "*.la" -or -name "*.pdb" -or -name "*.md" -delete
+
+ARG LIBRARY=base
+
+COPY . /src
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$LIBRARY" != "base" ]; then \
+        extra_reqs="" && \
+        if [ "$LIBRARY" = "all" ]; then \
+            extra_reqs="-r requirements/requirements_ctranslate2.txt -r requirements/requirements_nemo.txt"; \
+        elif [ "$LIBRARY" = "ctranslate2" ]; then \
+            extra_reqs="-r requirements/requirements_ctranslate2.txt"; \
+        elif [ "$LIBRARY" = "nemo" ]; then \
+            extra_reqs="-r requirements/requirements_nemo.txt"; \
+        fi && \
+        pip install --timeout 300 --root-user-action=ignore $extra_reqs && \
+        python -m pip cache purge && \
+        find / -type f -name "*.pyc" -delete && \
+        find / -type d -name "__pycache__" -exec rm -rf {} +; \
+    fi
+
+# Tell the dynamic link loader where to find the NVIDIA CUDA cuDNN libraries:
+ENV LD_LIBRARY_PATH="/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib/:/usr/local/cuda-12/lib64:$LD_LIBRARY_PATH"
+
+ENV PYTHONPATH="/src:$PYTHONPATH"
+
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -1,4 +1,88 @@
-# Open ASR Leaderboard
+# ASR Benchmarks - Open
+
+This repository is a fork of the [Open ASR Leaderboard repository](https://github.com/huggingface/open_asr_leaderboard) from Hugging Face. The idea is to contain the benchmarks in a Dockerized environment while caching the models and datasets in a separate volume on the host.
+
+## Prerequisites
+
+* System requirements:
+  * NVIDIA accelerator
+  * CUDA 12.3
+* System packages:
+  * Docker
+
+## Initialize
+
+1. Clone the repo
+    ```sh
+    git clone git@github.com:ilyakam/asr-benchmarks-open.git
+    ```
+
+1. Create a local folder for caching:
+    ```sh
+    mkdir -p cache
+    ```
+
+1. Create a `.env` file with the following content:
+    ```sh
+    HF_TOKEN=[REDACTED]
+    ```
+
+1. Build the Docker image for the desired library:
+    ```sh
+    export LIBRARY=[library] && docker build --build-arg LIBRARY=$LIBRARY -t asr-benchmarks-open:$LIBRARY .
+    ```
+
+## Benchmark
+
+- Run benchmarks for the desired library:
+    ```sh
+    docker compose run --rm benchmark-[library]
+    ```
+
+### Notes
+
+- The `base` library starts a shell in the container
+- Add `-e BATCH_SIZE=[batch size]` to override the default batch size of `128`:
+    ```sh
+    docker compose run --rm -e BATCH_SIZE=24 benchmark-[library]
+    ```
+- Add `-e MAX_EVAL_SAMPLES=[max eval samples]` to run a subset of samples:
+    ```sh
+    docker compose run --rm -e MAX_EVAL_SAMPLES=5 benchmark-[library]
+    ```
+
+### Examples
+
+- Rebuild and run `nemo` to benchmark `parakeet`:
+    ```sh
+    export LIBRARY=nemo && \
+    docker build --build-arg LIBRARY=$LIBRARY -t asr-benchmarks-open:$LIBRARY . && \
+    docker compose run --rm -e BATCH_SIZE=64 -e MAX_EVAL_SAMPLES=3 benchmark-nemo
+    ```
+- Rebuild and run `ctranslate2` to benchmark `faster-whisper`:
+    ```sh
+    export LIBRARY=ctranslate2 && \
+    docker build --build-arg LIBRARY=$LIBRARY -t asr-benchmarks-open:$LIBRARY . && \
+    docker compose run --rm -e BATCH_SIZE=24 -e MAX_EVAL_SAMPLES=5 benchmark-ctranslate2
+    ```
+
+## Libraries
+
+The following libraries were verified to be working:
+
+- [x] `base` (no library)
+- [x] `ctranslate2`
+- [ ] `granite`
+- [ ] `kyutai`
+- [ ] `moonshine`
+- [x] `nemo`
+- [ ] `phi`
+- [ ] `speechbrain`
+- [ ] `trtllm`
+
+---
+
+# Open ASR Leaderboard (Original)
 
 This repository contains the code for the Open ASR Leaderboard. The leaderboard is a Gradio Space that allows users to compare the accuracy of ASR models on a variety of datasets. The leaderboard is hosted at [hf-audio/open_asr_leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  benchmark-base:
+    image: asr-benchmarks-open:nemo
+    container_name: asr-benchmark-base
+    env_file:
+      - .env
+    volumes:
+      - ./cache:/root/.cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command: bash
+
+  # Service for running the Nemo benchmark
+  benchmark-nemo:
+    image: asr-benchmarks-open:nemo
+    container_name: asr-benchmark-nemo
+    env_file:
+      - .env
+    volumes:
+      - ./cache:/root/.cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - BATCH_SIZE=128
+    command: sh -c "cd /src/nemo_asr && ./run_fast_conformer_rnnt.sh"
+
+  # Service for running the CTranslate2 benchmark
+  benchmark-ctranslate2:
+    image: asr-benchmarks-open:ctranslate2
+    container_name: asr-benchmark-ctranslate2
+    env_file:
+      - .env
+    volumes:
+      - ./cache:/root/.cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - BATCH_SIZE=128
+    command: sh -c "cd /src/ctranslate2 && ./run_whisper.sh"


### PR DESCRIPTION
Run the benchmark scripts in Docker for consistency and portability.
Optimize for the smallest image size possible while taking advantage
of the Docker layers in order to minimize the build times.

Create a mountable cache volume to locally cache the models and dataset
sample files in order to speed up the benchmarks across builds.

Using Docker Compose, create services for each library (e.g., `nemo`,
`ctranslate2`, and so on). Set up environment variables for the batch
size and the number of evaluation samples. 

Note that not all libraries were tested at this time. It should be easy
to extend this pattern to the rest of the libraries.